### PR TITLE
76 consume the create user api from the signup page

### DIFF
--- a/backend/TaskTree/Controllers/UsersController.cs
+++ b/backend/TaskTree/Controllers/UsersController.cs
@@ -106,7 +106,26 @@ namespace TaskTree.Controllers
             var user = _mapper.Map<User>(createUserRequest);
 
             _context.Users.Add(user);
-            await _context.SaveChangesAsync();
+            try
+            {
+                await _context.SaveChangesAsync();
+
+            } catch(Exception e)
+            {
+                var exceptionCode = e.HResult;
+
+                // SQL server not running
+                if (exceptionCode == -2146233079) 
+                {
+                    return StatusCode(503, "Unable to connect to database");
+                }
+
+                // duplicate username
+                else if (exceptionCode == -2146233088) 
+                {
+                    return BadRequest("User already exists");
+                }
+            }
 
             return CreatedAtAction(nameof(GetUser), new { id = user.Id }, _mapper.Map<User, UserResponse>(user));
         }

--- a/frontend/src/services/UserService.ts
+++ b/frontend/src/services/UserService.ts
@@ -12,9 +12,15 @@ export default class UserService {
     return response.data;
   }
 
-  static async createUser(user: User): Promise<User> {
-    const response = await http.post('/users', user);
-    return response.data;
+  static async createUser(user: User): Promise<any> {
+    var response;
+    await http.post('/users', user)
+      .then(res => {
+        response = res;
+      }).catch(err => {
+        response = err.response;
+      });
+    return response;
   }
 
   // TODO: we should return the updated user from the endpoint


### PR DESCRIPTION
This PR hooks up the signup page frontend to the backend to create a user. It displays error messages if unable, and otherwise authorizes and stores the JWT for the newly created user as if they just logged in.

Here's what it looks like if the database is not running:
![image](https://user-images.githubusercontent.com/71574118/196333660-ddf62012-ed61-4557-8e26-90a0b389ff23.png)

Here's what it looks like if the username already exists:
![image](https://user-images.githubusercontent.com/71574118/196333769-ec78d157-61aa-4994-98e3-69131ae23a91.png)

And on a successful create, you can see it generates and stores a JWT for that user (user is created in db, it's just not something that's visual):
![image](https://user-images.githubusercontent.com/71574118/196333873-7de1f3fb-4744-4b4a-89d0-273bd5a7b262.png)


Closes #76 