### PR TITLE
made id field optional on task and project types

### DIFF
--- a/frontend/src/types/Project.ts
+++ b/frontend/src/types/Project.ts
@@ -1,7 +1,7 @@
 import Task from './Task';
 
 export default interface Project {
-  id: number;
+  id?: number;
   name: string;
   description?: string;
   root?: Task;

--- a/frontend/src/types/Task.ts
+++ b/frontend/src/types/Task.ts
@@ -1,5 +1,5 @@
 export default interface Task {
-  id: number;
+  id?: number;
   name: string;
   description?: string;
   progress: number;


### PR DESCRIPTION
Self explanatory, the main branch wasn't compiling because the id field was added in as mandatory on the task and project types, so they have been made optional. While every one of these objects will EVENTUALLY have an id, they won't upon creation in the frontend, so it should be optional.