### PR TITLE
Add functionality to task list component edit icon

### DIFF
--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -104,7 +104,6 @@ export default function TaskListItem(props: GetTaskFormProps) {
         task={props.task}
         onClose={() => setOpenEdit(false)}
         onSubmit={(formData) => {
-          console.log(formData);
           setOpenEdit(false);
           TaskService.updateTask(formData, props.task.id!);
         }}

--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -12,6 +12,7 @@ import LinearProgress, { LinearProgressProps } from '@mui/material/LinearProgres
 import { Alert, Box, Button, ListItem, ListItemIcon, ListItemSecondaryAction, Snackbar } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import TaskService from '../../services/TaskService';
+import EditTaskDialog from '../EditTaskDialog';
 
 interface GetTaskFormProps {
   task: Task;
@@ -33,14 +34,15 @@ function LinearProgressWithLabel(props: LinearProgressProps & { value: number })
 }
 
 export default function TaskListItem(props: GetTaskFormProps) {
-  const [open, setOpen] = React.useState(false);
+  const [openSnackbar, setOpenSnackbar] = React.useState(false);
+  const [openEdit, setOpenEdit] = React.useState(false);
 
   const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
       return;
     }
 
-    setOpen(false);
+    setOpenSnackbar(false);
   };
 
   return (
@@ -75,7 +77,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
-                  // do other stuff here
+                  setOpenEdit(true);
                 }}>
                 <EditIcon />
               </IconButton>
@@ -86,7 +88,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
                     e.preventDefault();
                     if (confirm(`Are you sure you want to delete task "${props.task.name}"?`)) {
                       TaskService.deleteTask(props.task.id!);
-                      setOpen(true);
+                      setOpenSnackbar(true);
                     }
                   }}>
                   <DeleteIcon />
@@ -96,8 +98,23 @@ export default function TaskListItem(props: GetTaskFormProps) {
           </Grid>
         </ListItemText>
       </ListItemButton>
+
+      <EditTaskDialog 
+        open={openEdit}
+        task={props.task}
+        onClose={() => setOpenEdit(false)}
+        onSubmit={(formData) => {
+          console.log(formData);
+          setOpenEdit(false);
+          props.task.name = formData.name;
+          props.task.description = formData.description;
+          props.task.weight = formData.weight;
+          TaskService.updateTask(props.task, props.task.id!);
+        }}
+      />
+
       <Snackbar 
-        open={open}
+        open={openSnackbar}
         autoHideDuration={6000}
         onClose={handleClose}
         message="Task successfully deleted"

--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -106,10 +106,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
         onSubmit={(formData) => {
           console.log(formData);
           setOpenEdit(false);
-          props.task.name = formData.name;
-          props.task.description = formData.description;
-          props.task.weight = formData.weight;
-          TaskService.updateTask(props.task, props.task.id!);
+          TaskService.updateTask(formData, props.task.id!);
         }}
       />
 


### PR DESCRIPTION
Pretty basic since the task list component isn't fully fleshed out, more work will need to be done when that happens

To test, I just put a task from the backend on the home page. Let me know if you want the code to do this.

Before editing:
![image](https://user-images.githubusercontent.com/71574118/200199996-2081aef9-cc8e-4cf7-ad58-566c0c0d1491.png)


On click:
![image](https://user-images.githubusercontent.com/71574118/200200039-deb02a7f-af6c-4a71-a880-02f641a14aca.png)


Edits made:
![image](https://user-images.githubusercontent.com/71574118/200200058-a56c6b05-36ee-4458-9110-ed616c0e067d.png)


After submit:
![image](https://user-images.githubusercontent.com/71574118/200200074-ed13628b-0884-4d37-88dc-06a5b2d07526.png)

