### PR TITLE
121 add separate view for a completed task

### DIFF
--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -9,7 +9,7 @@ import Typography from '@mui/material/Typography';
 import Task from '../../types/Task';
 import ListItemText from '@mui/material/ListItemText';
 import LinearProgress, { LinearProgressProps } from '@mui/material/LinearProgress';
-import { Alert, Box, Button, ListItem, ListItemIcon, ListItemSecondaryAction, Snackbar } from '@mui/material';
+import { Alert, Box, Button, createTheme, ListItem, ListItemIcon, ListItemSecondaryAction, Snackbar, ThemeProvider } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import TaskService from '../../services/TaskService';
 
@@ -17,23 +17,33 @@ interface GetTaskFormProps {
   task: Task;
 }
 
-function LinearProgressWithLabel(props: LinearProgressProps & { value: number }) {
+const theme = createTheme({
+  palette: {
+    secondary: {
+      main: "#34a853"
+    }
+  }
+});
+
+export default function TaskListItem(props: GetTaskFormProps) {
+  const [open, setOpen] = React.useState(false);
+
+  function LinearProgressWithLabel(progressProps: LinearProgressProps & { value: number }) {
   return (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
       <Box sx={{ width: '100%', mr: 1 }}>
-        <LinearProgress variant="determinate" {...props} />
+          <ThemeProvider theme={theme}>
+            <LinearProgress variant="determinate" color={props.task.completedAt ? 'secondary' : 'primary'} {...progressProps}/>
+          </ThemeProvider>
       </Box>
       <Box sx={{ minWidth: 35 }}>
         <Typography variant="body2" color="text.secondary">{`${Math.round(
-          props.value
+            progressProps.value
         )}%`}</Typography>
       </Box>
     </Box>
   );
 }
-
-export default function TaskListItem(props: GetTaskFormProps) {
-  const [open, setOpen] = React.useState(false);
 
   const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
@@ -48,7 +58,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
       <ListItemButton>
         <ListItemText disableTypography>
           <Grid container spacing={2} alignItems="center" justifyContent="space-between">
-            <Grid xs="auto" sx={{ display: 'flex', alignItems: 'center' }}>
+            <Grid xs={2} sx={{ display: 'flex', alignItems: 'center', paddingLeft: props.task.completedAt ? '40px' : '0' }}>
               {!props.task.completedAt &&
               <IconButton
                 onClick={(e) => {
@@ -67,11 +77,12 @@ export default function TaskListItem(props: GetTaskFormProps) {
                 variant="h6">{props.task.name}
               </Typography>
             </Grid>
-            <Grid xs={6}>
+            <Grid xs={8}>
               <LinearProgressWithLabel variant="determinate" value={props.task.progress} />
             </Grid>
+            {props.task.completedAt && <Grid xs={2} container justifyContent='center'></Grid>}
             {!props.task.completedAt &&
-            <Grid xs="auto">
+              <Grid xs={2} container justifyContent='center'>
               <IconButton
                 onClick={(e) => {
                   e.stopPropagation();

--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -49,6 +49,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
         <ListItemText disableTypography>
           <Grid container spacing={2} alignItems="center" justifyContent="space-between">
             <Grid xs="auto" sx={{ display: 'flex', alignItems: 'center' }}>
+              {!props.task.completedAt &&
               <IconButton
                 onClick={(e) => {
                   e.stopPropagation();
@@ -57,11 +58,19 @@ export default function TaskListItem(props: GetTaskFormProps) {
                 }}>
                 <CheckCircleOutlineIcon />
               </IconButton>
-              <Typography variant="h6">{props.task.name}</Typography>
+              }
+              <Typography 
+                sx={{
+                  textDecoration: props.task.completedAt ? 'line-through' : '',
+                  color: props.task.completedAt ? 'gray' : ''
+                }} 
+                variant="h6">{props.task.name}
+              </Typography>
             </Grid>
             <Grid xs={6}>
               <LinearProgressWithLabel variant="determinate" value={props.task.progress} />
             </Grid>
+            {!props.task.completedAt &&
             <Grid xs="auto">
               <IconButton
                 onClick={(e) => {
@@ -93,6 +102,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
                 </IconButton>
               )}
             </Grid>
+            }
           </Grid>
         </ListItemText>
       </ListItemButton>

--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -9,21 +9,13 @@ import Typography from '@mui/material/Typography';
 import Task from '../../types/Task';
 import ListItemText from '@mui/material/ListItemText';
 import LinearProgress, { LinearProgressProps } from '@mui/material/LinearProgress';
-import { Alert, Box, Button, createTheme, ListItem, ListItemIcon, ListItemSecondaryAction, Snackbar, ThemeProvider } from '@mui/material';
+import { Alert, Box, ListItem, Snackbar } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
 import TaskService from '../../services/TaskService';
 
 interface GetTaskFormProps {
   task: Task;
 }
-
-const theme = createTheme({
-  palette: {
-    secondary: {
-      main: "#34a853"
-    }
-  }
-});
 
 export default function TaskListItem(props: GetTaskFormProps) {
   const [open, setOpen] = React.useState(false);
@@ -32,9 +24,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
         <Box sx={{ width: '100%', mr: 1 }}>
-            <ThemeProvider theme={theme}>
-              <LinearProgress variant="determinate" color={props.task.completedAt ? 'secondary' : 'primary'} {...progressProps}/>
-            </ThemeProvider>
+            <LinearProgress variant="determinate" color={props.task.completedAt ? 'success' : 'primary'} {...progressProps}/>
         </Box>
         <Box sx={{ minWidth: 35 }}>
           <Typography variant="body2" color="text.secondary">{`${Math.round(
@@ -95,17 +85,15 @@ export default function TaskListItem(props: GetTaskFormProps) {
       <ListItemButton>
         <ListItemText disableTypography>
           <Grid container spacing={2} alignItems="center" justifyContent="space-between">
-            <Grid xs={2} sx={{ display: 'flex', alignItems: 'center', paddingLeft: props.task.completedAt ? '40px' : '0' }}>
-              {!props.task.completedAt &&
+            <Grid xs={2} sx={{ display: 'flex', alignItems: 'center'}}>
               <IconButton
                 onClick={(e) => {
                   e.stopPropagation();
                   e.preventDefault();
                   // do other stuff here
                 }}>
-                <CheckCircleOutlineIcon />
+                <CheckCircleOutlineIcon color={props.task.completedAt ? 'success' : 'primary'}/>
               </IconButton>
-              }
               <Typography 
                 sx={{
                   textDecoration: props.task.completedAt ? 'line-through' : '',

--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -18,60 +18,64 @@ interface GetTaskFormProps {
   task: Task;
 }
 
+interface ProgressBarProps extends LinearProgressProps {
+  task: Task;
+}
+
+function LinearProgressWithLabel(props: ProgressBarProps) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ width: '100%', mr: 1 }}>
+          <LinearProgress variant="determinate" color={props.task.completedAt ? 'success' : 'primary'} {...props}/>
+      </Box>
+      <Box sx={{ minWidth: 35 }}>
+        <Typography variant="body2" color="text.secondary">{`${Math.round(
+            props.task.progress
+        )}%`}</Typography>
+      </Box>
+    </Box>
+  );
+
+}
+
+function IconGrid(props: GetTaskFormProps & {setOpen: (e: boolean) => void }) {
+  return (
+    <Grid xs={2} container justifyContent='center'>
+      <IconButton
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          // do other stuff here
+        }}>
+        <AddIcon />
+      </IconButton>
+      <IconButton
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          // do other stuff here
+        }}>
+        <EditIcon />
+      </IconButton>
+      {props.task.projectId == null && (
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            if (confirm(`Are you sure you want to delete task "${props.task.name}"?`)) {
+              TaskService.deleteTask(props.task.id!);
+              props.setOpen(true);
+            }
+          }}>
+          <DeleteIcon />
+        </IconButton>
+      )}
+    </Grid>
+  );
+}
+
 export default function TaskListItem(props: GetTaskFormProps) {
   const [open, setOpen] = React.useState(false);
-
-  function LinearProgressWithLabel(progressProps: LinearProgressProps & { value: number }) {
-    return (
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        <Box sx={{ width: '100%', mr: 1 }}>
-            <LinearProgress variant="determinate" color={props.task.completedAt ? 'success' : 'primary'} {...progressProps}/>
-        </Box>
-        <Box sx={{ minWidth: 35 }}>
-          <Typography variant="body2" color="text.secondary">{`${Math.round(
-              progressProps.value
-          )}%`}</Typography>
-        </Box>
-      </Box>
-    );
-
-  }
-
-  function IconGrid() {
-    return (
-      <Grid xs={2} container justifyContent='center'>
-        <IconButton
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            // do other stuff here
-          }}>
-          <AddIcon />
-        </IconButton>
-        <IconButton
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            // do other stuff here
-          }}>
-          <EditIcon />
-        </IconButton>
-        {props.task.projectId == null && (
-          <IconButton
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              if (confirm(`Are you sure you want to delete task "${props.task.name}"?`)) {
-                TaskService.deleteTask(props.task.id!);
-                setOpen(true);
-              }
-            }}>
-            <DeleteIcon />
-          </IconButton>
-        )}
-      </Grid>
-    );
-  }
 
   const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
@@ -106,11 +110,11 @@ export default function TaskListItem(props: GetTaskFormProps) {
               </Typography>
             </Grid>
             <Grid xs={8}>
-              <LinearProgressWithLabel variant="determinate" value={props.task.progress} />
+              <LinearProgressWithLabel variant="determinate" task={props.task} />
             </Grid>
             {props.task.completedAt && <Grid xs={2} container justifyContent='center'></Grid>}
             {!props.task.completedAt &&
-              <IconGrid />
+              <IconGrid task={props.task} setOpen={setOpen} />
             }
           </Grid>
         </ListItemText>

--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import DeleteIcon from '@mui/icons-material/Delete';
 import IconButton from '@mui/material/IconButton';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
@@ -92,7 +93,9 @@ export default function TaskListItem(props: GetTaskFormProps) {
                   e.preventDefault();
                   // do other stuff here
                 }}>
-                <CheckCircleOutlineIcon color={props.task.completedAt ? 'success' : 'primary'}/>
+                {props.task.completedAt && <CheckCircleIcon color={props.task.completedAt ? 'success' : 'primary'}/>}
+                {!props.task.completedAt && <CheckCircleOutlineIcon color={props.task.completedAt ? 'success' : 'primary'}/>}
+                
               </IconButton>
               <Typography 
                 sx={{

--- a/frontend/src/components/TaskItem/index.tsx
+++ b/frontend/src/components/TaskItem/index.tsx
@@ -29,21 +29,58 @@ export default function TaskListItem(props: GetTaskFormProps) {
   const [open, setOpen] = React.useState(false);
 
   function LinearProgressWithLabel(progressProps: LinearProgressProps & { value: number }) {
-  return (
-    <Box sx={{ display: 'flex', alignItems: 'center' }}>
-      <Box sx={{ width: '100%', mr: 1 }}>
-          <ThemeProvider theme={theme}>
-            <LinearProgress variant="determinate" color={props.task.completedAt ? 'secondary' : 'primary'} {...progressProps}/>
-          </ThemeProvider>
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Box sx={{ width: '100%', mr: 1 }}>
+            <ThemeProvider theme={theme}>
+              <LinearProgress variant="determinate" color={props.task.completedAt ? 'secondary' : 'primary'} {...progressProps}/>
+            </ThemeProvider>
+        </Box>
+        <Box sx={{ minWidth: 35 }}>
+          <Typography variant="body2" color="text.secondary">{`${Math.round(
+              progressProps.value
+          )}%`}</Typography>
+        </Box>
       </Box>
-      <Box sx={{ minWidth: 35 }}>
-        <Typography variant="body2" color="text.secondary">{`${Math.round(
-            progressProps.value
-        )}%`}</Typography>
-      </Box>
-    </Box>
-  );
-}
+    );
+
+  }
+
+  function IconGrid() {
+    return (
+      <Grid xs={2} container justifyContent='center'>
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            // do other stuff here
+          }}>
+          <AddIcon />
+        </IconButton>
+        <IconButton
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            // do other stuff here
+          }}>
+          <EditIcon />
+        </IconButton>
+        {props.task.projectId == null && (
+          <IconButton
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              if (confirm(`Are you sure you want to delete task "${props.task.name}"?`)) {
+                TaskService.deleteTask(props.task.id!);
+                setOpen(true);
+              }
+            }}>
+            <DeleteIcon />
+          </IconButton>
+        )}
+      </Grid>
+    );
+  }
 
   const handleClose = (event: React.SyntheticEvent | Event, reason?: string) => {
     if (reason === 'clickaway') {
@@ -82,37 +119,7 @@ export default function TaskListItem(props: GetTaskFormProps) {
             </Grid>
             {props.task.completedAt && <Grid xs={2} container justifyContent='center'></Grid>}
             {!props.task.completedAt &&
-              <Grid xs={2} container justifyContent='center'>
-              <IconButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  // do other stuff here
-                }}>
-                <AddIcon />
-              </IconButton>
-              <IconButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  // do other stuff here
-                }}>
-                <EditIcon />
-              </IconButton>
-              {props.task.projectId == null && (
-                <IconButton
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    if (confirm(`Are you sure you want to delete task "${props.task.name}"?`)) {
-                      TaskService.deleteTask(props.task.id!);
-                      setOpen(true);
-                    }
-                  }}>
-                  <DeleteIcon />
-                </IconButton>
-              )}
-            </Grid>
+              <IconGrid />
             }
           </Grid>
         </ListItemText>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,12 +5,24 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { Provider } from 'react-redux';
 import { store } from './store/index';
+import createTheme from '@mui/material/styles/createTheme';
+import { ThemeProvider } from '@emotion/react';
+
+const theme = createTheme({
+  palette: {
+    success: {
+      main: "#34a853"
+    }
+  }
+});
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <Provider store={store}>
     <React.StrictMode>
-      <App />
+      <ThemeProvider theme={theme}>
+        <App />
+      </ThemeProvider>
     </React.StrictMode>
   </Provider>
 );


### PR DESCRIPTION
Upon completion of a task, there is now a different view in the task list item component. No buttons are available, and the progress bar turns green. I had to play around a little bit with the grid, as list components that had different length names were not aligned properly.

Also added a global theme to edit the colors of the MUI components, please make sure you take a look and see how that works

Before:
![image](https://user-images.githubusercontent.com/71574118/200210840-710bcdd7-a915-49c2-b44f-138fdb470f9e.png)


After:
![image](https://user-images.githubusercontent.com/71574118/200214132-69119a64-94b6-4a06-af24-5e1b4a04c302.png)
