### PR TITLE
implement global snackbar service

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,11 +12,23 @@ import { clearCurrentUser } from './store/user';
 import LandingPage from './pages/landing';
 import { authorizedRoutes, unauthorizedRoutes } from './router';
 import { useNavigate } from 'react-router-dom';
+import { Alert, Snackbar } from '@mui/material';
+import { SnackbarState } from './store/types';
+import { clearSnackbar } from './store/snackbar';
 
 function App() {
   const { isLoggedIn } = useAppSelector((state) => state.user);
+  const snackbar = useAppSelector((state) => state.snackbar);
   const dispatch = useAppDispatch();
   const routes = isLoggedIn ? authorizedRoutes : unauthorizedRoutes;
+
+  const handleClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    dispatch(clearSnackbar());
+  };
 
   const navItems = isLoggedIn
     ? [
@@ -66,6 +78,11 @@ function App() {
           })}
         </Routes>
       </Router>
+      <Snackbar open={snackbar.message !== ''} autoHideDuration={6000} onClose={handleClose}>
+        <Alert onClose={handleClose} severity={snackbar.severity} sx={{ width: '100%' }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </div>
   );
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,21 +1,24 @@
 import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './user';
-import { UserState } from './types';
+import snackbarReducer from './snackbar';
+import { SnackbarState, UserState } from './types';
 import AuthService from '../services/AuthService';
 
 export type RootState = {
   user: UserState;
+  snackbar: SnackbarState;
 };
 
 function preloadState(): RootState {
   const jwt = AuthService.getJWT();
   const user = AuthService.decodeJWT(jwt);
-  return { user: { current: user, isLoggedIn: !!user } };
+  return { user: { current: user, isLoggedIn: !!user }, snackbar: { message: '' } };
 }
 
 export const store = configureStore({
   reducer: {
-    user: userReducer
+    user: userReducer,
+    snackbar: snackbarReducer
   },
   preloadedState: preloadState(),
   devTools: true

--- a/frontend/src/store/snackbar.ts
+++ b/frontend/src/store/snackbar.ts
@@ -1,0 +1,24 @@
+import { createSlice, current, PayloadAction } from '@reduxjs/toolkit';
+import { SnackbarState } from './types';
+
+const initialState: SnackbarState = {
+  message: ''
+};
+
+export const snackbarSlice = createSlice({
+  name: 'snackbar',
+  initialState,
+  reducers: {
+    showSnackbar: (state, action: PayloadAction<SnackbarState>) => {
+      state.message = action.payload.message;
+      state.severity = action.payload.severity;
+    },
+    clearSnackbar: (_) => {
+      return initialState;
+    }
+  }
+});
+
+export const { showSnackbar, clearSnackbar } = snackbarSlice.actions;
+
+export default snackbarSlice.reducer;

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -4,3 +4,8 @@ export interface UserState {
   current: User | null;
   isLoggedIn: boolean;
 }
+
+export interface SnackbarState {
+  message: string;
+  severity?: 'success' | 'info' | 'warning' | 'error';
+}


### PR DESCRIPTION
This PR uses Redux to implement a global snackbar. To use/test this, in the component function use the dispatch: 
`const dispatch = useAppDispatch();`

Then, to show a snackbar, run the following:
`dispatch(showSnackbar({ message: 'test message!', severity: 'success'});`