### PR TITLE
Separate view for completed project

### DIFF
--- a/frontend/src/components/ProjectHeader/index.tsx
+++ b/frontend/src/components/ProjectHeader/index.tsx
@@ -47,7 +47,7 @@ export default function ProjectHeader(props: GetProjectFormProps) {
             
             marginRight: 'auto'
           }}>
-          {props.project.progress}% completed
+          {Math.round(props.project.progress)}% completed
         </Typography>
       </Typography>
   );

--- a/frontend/src/components/ProjectItem/index.tsx
+++ b/frontend/src/components/ProjectItem/index.tsx
@@ -26,15 +26,23 @@ interface GetProjectFormProps {
   onDelete: () => void;
 }
 
-function LinearProgressWithLabel(props: LinearProgressProps & { value: number }) {
+interface ProgressBarProps extends LinearProgressProps {
+  project: Project;
+}
+
+function LinearProgressWithLabel(props: ProgressBarProps) {
   return (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
       <Box sx={{ width: '100%', mr: 1 }}>
-        <LinearProgress variant="determinate" {...props} />
+        <LinearProgress
+          variant="determinate"
+          color={props.project.progress === 100 ? 'success' : 'primary'}
+          {...props}
+        />
       </Box>
       <Box sx={{ minWidth: 35 }}>
         <Typography variant="body2" color="text.secondary">{`${Math.round(
-          props.value
+          props.project.progress
         )}%`}</Typography>
       </Box>
     </Box>
@@ -50,10 +58,17 @@ export default function ProjectListItem(props: GetProjectFormProps) {
         <ListItemText disableTypography>
           <Grid container spacing={2} alignItems="center" justifyContent="space-between">
             <Grid xs={2} sx={{ display: 'flex', alignItems: 'center' }}>
-              <Typography variant="h6">{props.project.name}</Typography>
+              <Typography
+                sx={{
+                  textDecoration: props.project.progress === 100 ? 'line-through' : '',
+                  color: props.project.progress === 100 ? 'gray' : ''
+                }}
+                variant="h6">
+                {props.project.name}
+              </Typography>
             </Grid>
             <Grid xs={8}>
-              <LinearProgressWithLabel variant="determinate" value={props.project.progress} />
+              <LinearProgressWithLabel variant="determinate" project={props.project} />
             </Grid>
             <Grid xs={2} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
               <IconButton

--- a/frontend/src/components/ProjectItem/index.tsx
+++ b/frontend/src/components/ProjectItem/index.tsx
@@ -71,14 +71,17 @@ export default function ProjectListItem(props: GetProjectFormProps) {
               <LinearProgressWithLabel variant="determinate" project={props.project} />
             </Grid>
             <Grid xs={2} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-              <IconButton
-                onClick={(e) => {
-                  e.stopPropagation();
-                  e.preventDefault();
-                  setOpenEdit(true);
-                }}>
-                <EditIcon />
-              </IconButton>
+              {props.project.progress === 100 && <IconButton />}
+              {props.project.progress !== 100 && (
+                <IconButton
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    setOpenEdit(true);
+                  }}>
+                  <EditIcon />
+                </IconButton>
+              )}
 
               <IconButton
                 onClick={(e) => {

--- a/frontend/src/components/ProjectItem/index.tsx
+++ b/frontend/src/components/ProjectItem/index.tsx
@@ -26,7 +26,7 @@ interface GetProjectFormProps {
   onDelete: () => void;
 }
 
-interface ProgressBarProps extends LinearProgressProps {
+interface ProgressBarProps {
   project: Project;
 }
 
@@ -37,7 +37,7 @@ function LinearProgressWithLabel(props: ProgressBarProps) {
         <LinearProgress
           variant="determinate"
           color={props.project.progress === 100 ? 'success' : 'primary'}
-          {...props}
+          value={props.project.progress}
         />
       </Box>
       <Box sx={{ minWidth: 35 }}>
@@ -68,7 +68,7 @@ export default function ProjectListItem(props: GetProjectFormProps) {
               </Typography>
             </Grid>
             <Grid xs={8}>
-              <LinearProgressWithLabel variant="determinate" project={props.project} />
+              <LinearProgressWithLabel project={props.project} />
             </Grid>
             <Grid xs={2} sx={{ display: 'flex', justifyContent: 'flex-end' }}>
               {props.project.progress === 100 && <IconButton />}


### PR DESCRIPTION
When a project is completed, grays out and strikes through the project name, removes the edit button, and makes the progress bar green.

![image](https://user-images.githubusercontent.com/71574118/201822615-976f2d09-52f9-407b-be8e-7cd8bd90b35d.png)

