### PR TITLE
176 add confetti on project completion

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^0.27.2",
         "mui": "^0.0.1",
         "react": "^18.2.0",
+        "react-confetti": "^6.1.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.4",
         "react-router-dom": "^6.4.1",
@@ -18571,6 +18572,20 @@
       "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
       "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
     },
+    "node_modules/react-confetti": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
+      "integrity": "sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-8.0.0.tgz",
@@ -22735,6 +22750,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA=="
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
@@ -38461,6 +38481,14 @@
         }
       }
     },
+    "react-confetti": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
+      "integrity": "sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==",
+      "requires": {
+        "tween-functions": "^1.2.0"
+      }
+    },
     "react-dev-utils": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-8.0.0.tgz",
@@ -41733,6 +41761,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA=="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "axios": "^0.27.2",
     "mui": "^0.0.1",
     "react": "^18.2.0",
+    "react-confetti": "^6.1.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.4",
     "react-router-dom": "^6.4.1",

--- a/frontend/src/pages/project.tsx
+++ b/frontend/src/pages/project.tsx
@@ -5,19 +5,27 @@ import ExpandableTaskList from '../components/ExpandableTaskList';
 import { useParams } from 'react-router-dom';
 import ProjectService from '../services/ProjectService';
 import TaskListItem from '../components/TaskItem';
+import Confetti from 'react-confetti';
 
 export default function ProjectPage() {
   const params = useParams();
   const [project, setProject] = React.useState<Project>(BlankProject);
+  const [displayConfetti, setDisplayConfetti] = React.useState(false);
+  const [initComplete, setInitComplete] = React.useState(true);
 
-  const loadProject = () => {
+  const loadProject = (initRender: boolean) => {
     ProjectService.getProject(parseInt(params.projectId!)).then((project) => {
       setProject(project);
+      if (project.progress === 100 && initComplete === false && !initRender) {
+        setDisplayConfetti(true);
+        setTimeout(() => setDisplayConfetti(false), 5000);
+      }
     });
   };
 
   React.useEffect(() => {
-    loadProject();
+    loadProject(true);
+    setInitComplete(project.progress === 100);
   }, []);
 
   const TaskListTag =
@@ -25,8 +33,9 @@ export default function ProjectPage() {
 
   return (
     <>
+      <Confetti run={displayConfetti} numberOfPieces={1500} recycle={false} />
       <ProjectHeader project={project} />
-      <TaskListTag task={project.root!} reloadProject={loadProject} />
+      <TaskListTag task={project.root!} reloadProject={() => loadProject(false)} />
     </>
   );
 }


### PR DESCRIPTION
Displays confetti on project completion. The logic on the project page is as follows:

1. Don't display confetti the first time a page is loaded. This check works in conjunction with the check 2
2. Find out if project was complete to begin with. If it was, never display confetti.
3. When a project is loaded (more specifically, reloaded), which happens when a task is updated, if the progress is now 100%, display confetti

Keep in mind that the confetti is limited by my screen recorder's fps. In actuality it is smoother.

[Untitled_ Nov 15, 2022 12_02 AM.webm](https://user-images.githubusercontent.com/71574118/201831365-cb49536d-32c8-4f88-8a3f-251fba517571.webm)
