### PR TITLE
178 skeleton loader for task list

### DIFF
--- a/frontend/src/components/ProjectHeader/index.tsx
+++ b/frontend/src/components/ProjectHeader/index.tsx
@@ -1,54 +1,54 @@
 import * as React from 'react';
-import DeleteIcon from '@mui/icons-material/Delete';
-import IconButton from '@mui/material/IconButton';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import AddIcon from '@mui/icons-material/Add';
-import EditIcon from '@mui/icons-material/Edit';
-import ListItemButton from '@mui/material/ListItemButton';
 import Typography from '@mui/material/Typography';
-import Project from '../../types/Project';
-import ListItemText from '@mui/material/ListItemText';
-import LinearProgress, { LinearProgressProps } from '@mui/material/LinearProgress';
-import { Alert, Box, ListItem, Snackbar } from '@mui/material';
-import Grid from '@mui/material/Unstable_Grid2';
-import EditTaskDialog from '../EditTaskDialog';
+import Project, { BlankProject } from '../../types/Project';
+import { Skeleton } from '@mui/material';
 
 interface GetProjectFormProps {
   project: Project;
 }
 
 export default function ProjectHeader(props: GetProjectFormProps) {
-
   return (
-    <Typography component="h3" variant="h3"
+    <Typography
+      component="h3"
+      variant="h3"
       sx={{
         marginTop: 8,
         display: 'flex',
         flexDirection: 'row',
-        width: '100%',
+        width: '100%'
       }}>
-        <Typography align='left'
-          component="h3"
-          variant="h3"
-          sx={{
-            justifySelf: 'left',
-            marginRight: 'auto',
-            marginLeft: '30px'
-          }}>
-          {props.project.name}
-        </Typography>
-
-        <Typography align='center'
-          component="h3"
-          variant="h3"
-          sx={{
-            justifySelf: 'center',
-            
-            marginRight: 'auto'
-          }}>
-          {Math.round(props.project.progress)}% completed
-        </Typography>
+      <Typography
+        align="left"
+        component="h3"
+        variant="h3"
+        sx={{
+          justifySelf: 'left',
+          marginRight: 'auto',
+          marginLeft: '30px'
+        }}>
+        {props.project !== BlankProject ? (
+          props.project.name
+        ) : (
+          <Skeleton variant="rounded" sx={{ width: 300, height: 56 }} />
+        )}
       </Typography>
+
+      <Typography
+        align="center"
+        component="h3"
+        variant="h3"
+        sx={{
+          justifySelf: 'center',
+
+          marginRight: 'auto'
+        }}>
+        {props.project !== BlankProject ? (
+          `${Math.round(props.project.progress)}% completed`
+        ) : (
+          <Skeleton variant="rounded" sx={{ width: 300, height: 56 }} />
+        )}
+      </Typography>
+    </Typography>
   );
 }

--- a/frontend/src/pages/project.tsx
+++ b/frontend/src/pages/project.tsx
@@ -27,7 +27,7 @@ export default function ProjectPage() {
   };
 
   React.useEffect(() => {
-    setTimeout(() => loadProject(true), 3000);
+    loadProject(true);
     setInitComplete(project.progress === 100);
   }, []);
 
@@ -47,20 +47,6 @@ export default function ProjectPage() {
       {project != BlankProject ? (
         <TaskListTag task={project.root!} reloadProject={() => loadProject(false)} />
       ) : (
-        // <Grid
-        //   container
-        //   spacing={2}
-        //   sx={{ direction: 'row', justifyContent: 'center', marginTop: '10px' }}>
-        //   <Grid item xs={11}>
-        //     <Skeleton variant="rounded" height={56} />
-        //   </Grid>
-        //   <Grid item xs={11}>
-        //     <Skeleton variant="rounded" height={56} />
-        //   </Grid>
-        //   <Grid item xs={11}>
-        //     <Skeleton variant="rounded" height={56} />
-        //   </Grid>
-        // </Grid>
         <Skeleton
           variant="rounded"
           height={56}

--- a/frontend/src/pages/project.tsx
+++ b/frontend/src/pages/project.tsx
@@ -6,10 +6,11 @@ import { useParams } from 'react-router-dom';
 import ProjectService from '../services/ProjectService';
 import TaskListItem from '../components/TaskItem';
 import Confetti from 'react-confetti';
-import { useWindowSize } from '../App'
+import { useWindowSize } from '../App';
+import { Grid, Skeleton } from '@mui/material';
 
 export default function ProjectPage() {
-  const windowSize = useWindowSize()
+  const windowSize = useWindowSize();
   const params = useParams();
   const [project, setProject] = React.useState<Project>(BlankProject);
   const [displayConfetti, setDisplayConfetti] = React.useState(false);
@@ -26,7 +27,7 @@ export default function ProjectPage() {
   };
 
   React.useEffect(() => {
-    loadProject(true);
+    setTimeout(() => loadProject(true), 3000);
     setInitComplete(project.progress === 100);
   }, []);
 
@@ -35,9 +36,38 @@ export default function ProjectPage() {
 
   return (
     <>
-      <Confetti width={windowSize.width} height={windowSize.height} run={displayConfetti} numberOfPieces={1500} recycle={false} />
+      <Confetti
+        width={windowSize.width}
+        height={windowSize.height}
+        run={displayConfetti}
+        numberOfPieces={1500}
+        recycle={false}
+      />
       <ProjectHeader project={project} />
-      <TaskListTag task={project.root!} reloadProject={() => loadProject(false)} />
+      {project != BlankProject ? (
+        <TaskListTag task={project.root!} reloadProject={() => loadProject(false)} />
+      ) : (
+        // <Grid
+        //   container
+        //   spacing={2}
+        //   sx={{ direction: 'row', justifyContent: 'center', marginTop: '10px' }}>
+        //   <Grid item xs={11}>
+        //     <Skeleton variant="rounded" height={56} />
+        //   </Grid>
+        //   <Grid item xs={11}>
+        //     <Skeleton variant="rounded" height={56} />
+        //   </Grid>
+        //   <Grid item xs={11}>
+        //     <Skeleton variant="rounded" height={56} />
+        //   </Grid>
+        // </Grid>
+        <Skeleton
+          variant="rounded"
+          height={56}
+          width={'95%'}
+          sx={{ margin: 'auto', marginTop: '10px' }}
+        />
+      )}
     </>
   );
 }

--- a/frontend/src/types/Project.ts
+++ b/frontend/src/types/Project.ts
@@ -11,8 +11,8 @@ export default interface Project {
 
 export const BlankProject: Project = {
   id: 0,
-  name: 'blank',
-  description: 'blank',
+  name: '',
+  description: '',
   progress: 0,
   root: BlankTask
 };


### PR DESCRIPTION
Added a skeleton loader to the task list on a project page for when it is loading.

To test it, I updated line 30 in `src/pages/project.tsx` to be `setTimeout(() => loadProject(true), 3000);`

I also updated the `BlankProject`, since it would actually display the name "blank" while the project page was loading

![TaskTree (2)](https://user-images.githubusercontent.com/71574118/202073492-3ae97244-13e7-4c4a-a9ac-f167c9fe64d7.gif)
