### PR TITLE
177 skeleton loader for project list

### DIFF
--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Box, Typography } from '@mui/material';
-import User, { BlankUser } from '../types/User';
-import AuthService from '../services/AuthService';
+import { Box, Grid, Skeleton, Typography } from '@mui/material';
+import { BlankUser } from '../types/User';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import Project from '../types/Project';
 import ProjectService from '../services/ProjectService';
@@ -41,7 +40,17 @@ export default function HomePage() {
       <Typography variant="h5">Recent projects</Typography>
       <br />
       <Box sx={{ px: 12, mx: 12 }}>
-        <ProjectList projects={getRecentProjects(projects)} setProjects={setProjects} />
+        {projects.length > 0 ? (
+          <ProjectList projects={getRecentProjects(projects)} setProjects={setProjects} />
+        ) : (
+          <Grid container spacing={2} sx={{ direction: 'row', justifyContent: 'center' }}>
+            {Array(4).fill(
+              <Grid item xs={12}>
+                <Skeleton variant="rounded" height={64} />
+              </Grid>
+            )}
+          </Grid>
+        )}
       </Box>
     </>
   );

--- a/frontend/src/pages/projects.tsx
+++ b/frontend/src/pages/projects.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import ListItem from '@mui/material/ListItem';
-import { FixedSizeList, ListChildComponentProps } from 'react-window';
-import { Box, Button, Typography, Snackbar, Alert } from '@mui/material';
+import { Box, Button, Grid, Skeleton, Typography } from '@mui/material';
 import ProjectService from '../services/ProjectService';
-import Project, { BlankProject } from '../types/Project';
+import Project from '../types/Project';
 import CreateProjectDialog from '../components/CreateProjectDialog';
-import ProjectListItem from '../components/ProjectItem';
 import ProjectList from '../components/ProjectList';
 import { showSnackbar } from '../store/snackbar';
 import { useAppDispatch } from '../store/hooks';
@@ -84,7 +81,17 @@ export default function ProjectsPage() {
 
       <CreateProjectDialog open={open} onClose={handleClose} onSubmit={handleSubmit} />
 
-      <ProjectList projects={projects} setProjects={setProjects} />
+      {projects.length > 0 ? (
+        <ProjectList projects={projects} setProjects={setProjects} />
+      ) : (
+        <Grid container spacing={2} sx={{ direction: 'row', justifyContent: 'center' }}>
+          {Array(4).fill(
+            <Grid item xs={12}>
+              <Skeleton variant="rounded" height={64} />
+            </Grid>
+          )}
+        </Grid>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
Added a skeleton loader to the project list on the projects page and home page for when it is loading.

To test it, I updated changed the `setProjects` call in the `React.useEffect` to `setTimeout(async () => setProjects(await ProjectService.getProjects()), 3000);`



The below gif only shows on the projects page, but the same code has been implemented on the home page
![TaskTree (3)](https://user-images.githubusercontent.com/71574118/202094413-7590b8b0-13d1-4b0e-aca5-4e4e04e74178.gif)

